### PR TITLE
Release 0.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Provides compatibility between the [Simple Local Avatars](https://wordpress.org/
 
 ### Notes
 
-* Tested with Simple Local Avatars version 2.8.3
+* Tested with Simple Local Avatars version 2.8.5
 
 ### Support, Feedback, & Contribute
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
 == Changelog ==
+= 0.0.2 =
+- FIX: PHP warning on empty user meta value.
+
 = 0.0.1 =
 * Initial public release.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 == Changelog ==
 = 0.0.2 =
-- FIX: PHP warning on empty user meta value.
+- FIX: PHP warning on empty user meta value [823](https://github.com/udx/wp-stateless/issues/823).
 
 = 0.0.1 =
 * Initial public release.

--- a/changes.md
+++ b/changes.md
@@ -1,6 +1,6 @@
 #### 0.0.2
 
-- FIX: PHP warning on empty user meta value.
+- FIX: PHP warning on empty user meta value [823](https://github.com/udx/wp-stateless/issues/823).
 
 #### 0.0.1
 

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,7 @@
+#### 0.0.2
+
+- FIX: PHP warning on empty user meta value.
+
 #### 0.0.1
 
 - Initial public release.

--- a/class-simple-local-avatars.php
+++ b/class-simple-local-avatars.php
@@ -64,7 +64,7 @@ class SimpleLocalAvatars extends Compatibility {
     }
 
     // Return filtered data back
-    return $user_meta;
+    return empty($user_meta) ? null : $user_meta;
   }
 
   /**

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Tags: simple local avatars, simple local avatars addon extension, google cloud s
 License: GPLv2 or later
 Requires PHP: 8.0
 Requires at least: 5.0
-Tested up to: 6.8
-Stable tag: 0.0.1
+Tested up to: 6.9
+Stable tag: 0.0.2
 
 Provides compatibility between the Simple Local Avatars and the WP-Stateless plugins.
 
@@ -20,7 +20,15 @@ Provides compatibility between the [Simple Local Avatars](https://wordpress.org/
 
 = Notes =
 
-* Tested with Simple Local Avatars version 2.8.3
+* Tested with Simple Local Avatars version 2.8.5
+
+== Changelog ==
+
+= 0.0.2 =
+- FIX: PHP warning on empty user meta value.
+
+= 0.0.1 =
+* Initial public release.
 
 = Support, Feedback, & Contribute =
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: simple local avatars, simple local avatars addon extension, google cloud s
 License: GPLv2 or later
 Requires PHP: 8.0
 Requires at least: 5.0
-Tested up to: 6.8
+Tested up to: 6.8.1
 Stable tag: 0.0.1
 
 Provides compatibility between the Simple Local Avatars and the WP-Stateless plugins.

--- a/readme.txt
+++ b/readme.txt
@@ -25,7 +25,7 @@ Provides compatibility between the [Simple Local Avatars](https://wordpress.org/
 == Changelog ==
 
 = 0.0.2 =
-- FIX: PHP warning on empty user meta value.
+- FIX: PHP warning on empty user meta value [823](https://github.com/udx/wp-stateless/issues/823).
 
 = 0.0.1 =
 * Initial public release.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: simple local avatars, simple local avatars addon extension, google cloud s
 License: GPLv2 or later
 Requires PHP: 8.0
 Requires at least: 5.0
-Tested up to: 6.8.1
+Tested up to: 6.8
 Stable tag: 0.0.1
 
 Provides compatibility between the Simple Local Avatars and the WP-Stateless plugins.

--- a/wp-stateless-simple-local-avatars-addon.php
+++ b/wp-stateless-simple-local-avatars-addon.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://stateless.udx.io/addons/simple-local-avatars/
  * Description: Provides compatibility between the Simple Local Avatars and the WP-Stateless plugins.
  * Author: UDX
- * Version: 0.0.1
+ * Version: 0.0.2
  * Text Domain: wp-stateless-simple-local-avatars-addon
  * Author URI: https://udx.io
  * License: GPLv2 or later


### PR DESCRIPTION
- FIX: PHP warning on empty user meta value [823](https://github.com/udx/wp-stateless/issues/823).